### PR TITLE
git: add gitattribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# gitattributes file
+#  https://github.com/github/linguist/blob/master/docs/overrides.md
+
+* -text
+
+*.vim     linguist-language=Dockerfile
+*.neovim  linguist-language=Dockerfile


### PR DESCRIPTION
Add a `.gitattributes` file for syntax highlighting of `Dockerfile`.