### PR TITLE
:+1: Add tags to docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       denops_version:
         description: Denops version
         required: false
-        default: "main"
+        default: "v5.0.0"  # or "main"
 
 jobs:
   build:
@@ -32,4 +32,21 @@ jobs:
           fi
         shell: bash
       - run: make DENOPS_VERSION=${{ steps.vars.outputs.DENOPS_VERSION }} build
+
+      - name: Push to ghcr.io
+        env:
+          DENOPS_VERSION: ${{ steps.vars.outputs.DENOPS_VERSION }}
+        shell: bash
+        run: |
+          if [[ ${{ env.DENOPS_VERSION }} == "v*" ]]; then
+            # Full version string
+            make DENOPS_VERSION={{ env.DENOPS_VERSION }} push
+            # vX.Y.Z -> vX (major only)
+            make DENOPS_VERSION=$(echo $DENOPS_VERSION | sed -r 's/(v[0-9]+)(\.[0-9]+)(\.[0-9]+)/\1/') push
+            # vX.Y.Z -> vX.Y (major and minor)
+            make DENOPS_VERSION=$(echo $DENOPS_VERSION | sed -r 's/(v[0-9]+)(\.[0-9]+)(\.[0-9]+)/\1\2/') push
+          fi
+          make DENOPS_VERSION=latest push
+
+
       - run: make DENOPS_VERSION=${{ steps.vars.outputs.DENOPS_VERSION }} push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,27 +26,26 @@ jobs:
         id: vars
         run: |
           if [[ -z "${{ github.event.inputs.denops_version }}" ]]; then
-            echo '::set-output name=DENOPS_VERSION::main'
+            echo '::set-output name=DENOPS_VERSION::v5.0.0'
           else
             echo '::set-output name=DENOPS_VERSION::${{ github.event.inputs.denops_version }}'
           fi
         shell: bash
-      - run: make DENOPS_VERSION=${{ steps.vars.outputs.DENOPS_VERSION }} build
 
-      - name: Push to ghcr.io
+      - name: Build and Push to ghcr.io
         env:
           DENOPS_VERSION: ${{ steps.vars.outputs.DENOPS_VERSION }}
         shell: bash
         run: |
-          if [[ ${{ env.DENOPS_VERSION }} == "v*" ]]; then
+          make DENOPS_VERSION=$DENOPS_VERSION build
+          if [[ $DENOPS_VERSION == v* ]]; then
             # Full version string
-            make DENOPS_VERSION={{ env.DENOPS_VERSION }} push
-            # vX.Y.Z -> vX (major only)
-            make DENOPS_VERSION=$(echo $DENOPS_VERSION | sed -r 's/(v[0-9]+)(\.[0-9]+)(\.[0-9]+)/\1/') push
+            make DOCKER_TAG=$DENOPS_VERSION push
             # vX.Y.Z -> vX.Y (major and minor)
-            make DENOPS_VERSION=$(echo $DENOPS_VERSION | sed -r 's/(v[0-9]+)(\.[0-9]+)(\.[0-9]+)/\1\2/') push
+            export DOCKER_TAG_MINOR=$(echo $DENOPS_VERSION | sed -r 's/(v[0-9]+)(\.[0-9]+)(\.[0-9]+)/\1\2/')
+            make DOCKER_TAG=$DOCKER_TAG_MINOR push
+            # vX.Y.Z -> vX (major only)
+            export DOCKER_TAG_MAJOR=$(echo $DENOPS_VERSION | sed -r 's/(v[0-9]+)(\.[0-9]+)(\.[0-9]+)/\1/')
+            make DOCKER_TAG=$DOCKER_TAG_MAJOR push
           fi
-          make DENOPS_VERSION=latest push
-
-
-      - run: make DENOPS_VERSION=${{ steps.vars.outputs.DENOPS_VERSION }} push
+          make DOCKER_TAG=latest push

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DENOPS_VERSION := main
+DOCKER_TAG := latest
 DOCKER_REGISTRY := ghcr.io/vim-denops
 
 .DEFAULT_GOAL := help
@@ -17,7 +18,7 @@ build-vim: FORCE	## Build (Vim)
 			--cache-from=${DOCKER_REGISTRY}/vim \
 			--cache-to=type=registry,ref=${DOCKER_REGISTRY}/vim/cache,mode=max \
 		--build-arg DENOPS_VERSION=${DENOPS_VERSION} \
-		-t ${DOCKER_REGISTRY}/vim \
+		-t denops-dockerfile/vim \
 		-f Dockerfile.vim \
 		.
 
@@ -28,18 +29,18 @@ build-neovim: FORCE	## Build (Neovim)
 			--cache-from=${DOCKER_REGISTRY}/neovim \
 			--cache-to=type=registry,ref=${DOCKER_REGISTRY}/neovim/cache,mode=max \
 		--build-arg DENOPS_VERSION=${DENOPS_VERSION} \
-		-t ${DOCKER_REGISTRY}/neovim \
+		-t denops-dockerfile/neovim \
 		-f Dockerfile.neovim \
 		.
 
 push: push-vim push-neovim	## Push
 
 push-vim: FORCE	## Push (Vim)
-	docker tag ${DOCKER_REGISTRY}/vim ${DOCKER_REGISTRY}/vim:${DENOPS_VERSION}
-	docker push ${DOCKER_REGISTRY}/vim:${DENOPS_VERSION}
+	docker tag denops-dockerfile/vim ${DOCKER_REGISTRY}/vim:${DOCKER_TAG}
+	docker push ${DOCKER_REGISTRY}/vim:${DOCKER_TAG}
 
 push-neovim: FORCE	## Push (Neovim)
-	docker tag ${DOCKER_REGISTRY}/neovim ${DOCKER_REGISTRY}/neovim:${DENOPS_VERSION}
-	docker push ${DOCKER_REGISTRY}/neovim:${DENOPS_VERSION}
+	docker tag denops-dockerfile/neovim ${DOCKER_REGISTRY}/neovim:${DOCKER_TAG}
+	docker push ${DOCKER_REGISTRY}/neovim:${DOCKER_TAG}
 
 FORCE:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DENOPS_VERSION := main
+DOCKER_REGISTRY := ghcr.io/vim-denops
 
 .DEFAULT_GOAL := help
 
@@ -12,35 +13,33 @@ build: build-vim build-neovim	## Build
 build-vim: FORCE	## Build (Vim)
 	docker buildx build ${BUILD_ARGS} \
 		--load \
-	    	--cache-from=ghcr.io/vim-denops/vim/cache \
-	    	--cache-from=ghcr.io/vim-denops/vim \
-	    	--cache-to=type=registry,ref=ghcr.io/vim-denops/vim/cache,mode=max \
+			--cache-from=${DOCKER_REGISTRY}/vim/cache \
+			--cache-from=${DOCKER_REGISTRY}/vim \
+			--cache-to=type=registry,ref=${DOCKER_REGISTRY}/vim/cache,mode=max \
 		--build-arg DENOPS_VERSION=${DENOPS_VERSION} \
-		-t ghcr.io/vim-denops/vim:${DENOPS_VERSION} \
-		-t ghcr.io/vim-denops/vim \
+		-t ${DOCKER_REGISTRY}/vim \
 		-f Dockerfile.vim \
 		.
 
 build-neovim: FORCE	## Build (Neovim)
 	docker buildx build ${BUILD_ARGS} \
 		--load \
-	    	--cache-from=ghcr.io/vim-denops/neovim/cache \
-	    	--cache-from=ghcr.io/vim-denops/neovim \
-	    	--cache-to=type=registry,ref=ghcr.io/vim-denops/neovim/cache,mode=max \
+			--cache-from=${DOCKER_REGISTRY}/neovim/cache \
+			--cache-from=${DOCKER_REGISTRY}/neovim \
+			--cache-to=type=registry,ref=${DOCKER_REGISTRY}/neovim/cache,mode=max \
 		--build-arg DENOPS_VERSION=${DENOPS_VERSION} \
-		-t ghcr.io/vim-denops/neovim:${DENOPS_VERSION} \
-		-t ghcr.io/vim-denops/neovim \
+		-t ${DOCKER_REGISTRY}/neovim \
 		-f Dockerfile.neovim \
 		.
 
 push: push-vim push-neovim	## Push
 
 push-vim: FORCE	## Push (Vim)
-	docker push ghcr.io/vim-denops/vim:${DENOPS_VERSION}
-	docker push ghcr.io/vim-denops/vim
+	docker tag ${DOCKER_REGISTRY}/vim ${DOCKER_REGISTRY}/vim:${DENOPS_VERSION}
+	docker push ${DOCKER_REGISTRY}/vim:${DENOPS_VERSION}
 
 push-neovim: FORCE	## Push (Neovim)
-	docker push ghcr.io/vim-denops/neovim:${DENOPS_VERSION}
-	docker push ghcr.io/vim-denops/neovim
+	docker tag ${DOCKER_REGISTRY}/neovim ${DOCKER_REGISTRY}/neovim:${DENOPS_VERSION}
+	docker push ${DOCKER_REGISTRY}/neovim:${DENOPS_VERSION}
 
 FORCE:


### PR DESCRIPTION
close: #10 

## Changes Summary

- `.github/workflows/build.yml`
    - Pin denops version to v5.0.0
    - Re-write into a multi-tagging step
- `Makefile`
    - Cut-out to the `DOCKER_REGISTRY` variable docker registry target
    - Move tagging from `build` to `push` task
        - **NEED OPNION**: Included in the push task, but could be independent